### PR TITLE
fix(sec): upgrade lxml to 4.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ google-cloud-error-reporting==1.1.0
 google-cloud-language==2.0.0
 google-cloud-logging==2.0.2
 holidays==0.10.5.2
-lxml==4.6.5
+lxml==4.9.1
 oauth2==1.9.0.post1
 polygon-api-client==0.1.9
 pytest==6.2.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in lxml 4.6.5
- [CVE-2022-2309](https://www.oscs1024.com/hd/CVE-2022-2309)


### What did I do？
Upgrade lxml from 4.6.5 to 4.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS